### PR TITLE
Support Angular 10

### DIFF
--- a/projects/ngx-date-fns/src/lib/date-fns.module.ts
+++ b/projects/ngx-date-fns/src/lib/date-fns.module.ts
@@ -244,7 +244,7 @@ const PIPES = [
   exports: PIPES
 })
 export class DateFnsModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<DateFnsModule> {
     return {
       ngModule: DateFnsModule,
       providers: [DateFnsConfigurationService]


### PR DESCRIPTION
With Angular 10, the `ModuleWithProviders` interfaces has a mandatory generic parameter.

It is not given in ngx-date-fns : https://github.com/joanllenas/ngx-date-fns/blob/d009bb69811bc96201708c0ace6c794ae7e4f2f7/projects/ngx-date-fns/src/lib/date-fns.module.ts#L247

This results in the following error :

```
node_modules/ngx-date-fns/lib/date-fns.module.d.ts:3:23 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

3     static forRoot(): ModuleWithProviders;
                        ~~~~~~~~~~~~~~~~~~~
```

This is a PR just to fix this, (it is unlikely but) there may be more changes needed elsewhere.