### PR TITLE
refactor: remove no-op imports from NgModule

### DIFF
--- a/projects/ngx-date-fns/src/lib/date-fns.module.ts
+++ b/projects/ngx-date-fns/src/lib/date-fns.module.ts
@@ -269,7 +269,6 @@ const PIPES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, PIPES],
   exports: PIPES
 })
 export class DateFnsModule {


### PR DESCRIPTION
The `imports` option of an Angular module that doesn't declare any components, does exactly nothing, so there's no reason to include it.

This is a non-breaking change. If anything, it reduces the bundle size.