### PR TITLE
feat(pipes): added formatDuration pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,47 @@
 
 [date-fns](https://date-fns.org/) pipes for Angular 2.0 and above.
 
+## Table Of Contents
+
+- [Installation](#installation)
+- [date-fns v1 support](#v1-support)
+- [Basic Usage](#usage)
+- [Working with locales](#locales)
+  - [Changing locale globally](#locale-globally)
+  - [Changing locale at runtime](#locale-runtime)
+  - [_Pure_ or _impure_?](#pure-impure)
+- [Tree shaking date-fns](#tree-shaking)
+- [Available pipes](#pipes)
+  - [Misc. pipes](#misc-pipes)
+  - [Format... pipes](#format-pipes)
+  - [Get... pipes](#get-pipes)
+  - [Difference... pipes](#difference-pipes)
+  - [Add... pipes](#add-pipes)
+  - [Subtract... pipes](#subtract-pipes)
+  - [End... pipes](#end-pipes)
+  - [Start... pipes](#start-pipes)
+  - [Last day of... pipes](#last-day-of-pipes)
+  - [Is... pipes](#is-pipes)
+- [Utils](#utils)
+
+<a name="installation" />
+
 ## Installation
 
-This library has been tested with [date-fns](https://date-fns.org/) v2.0.1.
+This library requires [date-fns](https://date-fns.org/) `>= v2.16.0`.
 
-```
-npm install --save date-fns
-npm install --save ngx-date-fns
-```
+- `npm install --save date-fns`
+- `npm install --save ngx-date-fns`
 
-For date-fns v1 support:
+<a name="v1-support" />
 
-```
-npm install --save date-fns@1.29.0
-npm install --save ngx-date-fns@4.0.3
-```
+#### date-fns v1 support
 
-> [ngx-date-fns@4.0.3 docs](https://github.com/joanllenas/ngx-date-fns/tree/v4.0.3)
+- `npm install --save date-fns@1.29.0`
+- `npm install --save ngx-date-fns@4.0.3`
+- [ngx-date-fns@4.0.3 docs](https://github.com/joanllenas/ngx-date-fns/tree/v4.0.3)
+
+<a name="usage" />
 
 ## Basic Usage
 
@@ -83,9 +107,13 @@ Sun January 1 2017
 hace 6 días
 ```
 
+<a name="locales" />
+
 ## Working with locales
 
 > All locale-aware pipes use English by default.
+
+<a name="locale-globally" />
 
 ### Changing locale globally
 
@@ -109,6 +137,8 @@ frenchConfig.setLocale(fr);
   ]
 })
 ```
+
+<a name="locale-runtime" />
 
 ### Changing locale at runtime
 
@@ -140,6 +170,8 @@ export class AppComponent {
 }
 ```
 
+<a name="pure-impure" />
+
 ### _Pure_ or _impure_?
 
 Should I use the _pure_ or _impure_ version of the locale-aware pipes?
@@ -152,6 +184,8 @@ The answer is quite simple:
   - Use _impure_ pipes.
 
 The main difference is that _pure_ pipes do not get notified when the locale is changed via `DateFnsConfiguration.setLocale(locale: Locale)`, because the instance is not kept in memory. Impure _pipes_, on the other hand, are kept in memory and listen for Locale change notifications, which adds some memory and performance overhead.
+
+<a name="tree-shaking" />
 
 ## Tree shaking date-fns
 
@@ -199,171 +233,197 @@ This command will load a file in your browser where you will see that `date-fns`
 
 Also take into account that locale files tend to increase the final bundle size of `date-fns` as well.
 
+<a name="pipes" />
+
 ## Available pipes
 
 > All pipes are pure unless stated otherwise.
+
+<a name="misc-pipes" />
+
+#### Misc
+
+- [dfnsParse](https://date-fns.org/v2.16.0/docs/parse) _([impure](#pure-or-impure))_
+  - [dfnsParsePure](https://date-fns.org/v2.16.0/docs/parse)
+- [dfnsParseIso](https://date-fns.org/v2.16.0/docs/parseISO)
+- [dfnsClosestTo](https://date-fns.org/v2.16.0/docs/closestTo)
+- [dfnsMin](https://date-fns.org/v2.16.0/docs/min)
+- [dfnsMax](https://date-fns.org/v2.16.0/docs/max)
+
+<a name="format-pipes" />
 
 #### Format
 
 > Since `v7.0.0` invalid Dates will return an empty string instead of throwing an exception.
 
-- [dfnsFormat](https://date-fns.org/v2.0.1/docs/format) _([impure](#pure-or-impure))_
-  - [dfnsFormatPure](https://date-fns.org/v2.0.1/docs/format)
-- [dfnsFormatDistance](https://date-fns.org/v2.0.1/docs/formatDistance) _([impure](#pure-or-impure))_
-  - [dfnsFormatDistancePure](https://date-fns.org/v2.0.1/docs/formatDistance)
-- [dfnsFormatDistanceStrict](https://date-fns.org/v2.0.1/docs/formatDistanceStrict) _([impure](#pure-or-impure))_
-  - [dfnsFormatDistanceStrictPure](https://date-fns.org/v2.0.1/docs/formatDistanceStrict)
-- [dfnsFormatDistanceToNow](https://date-fns.org/v2.0.1/docs/formatDistanceToNow) _([impure](#pure-or-impure))_
-  - [dfnsFormatDistanceToNowPure](https://date-fns.org/v2.0.1/docs/formatDistanceToNow)
+- [dfnsFormat](https://date-fns.org/v2.16.0/docs/format) _([impure](#pure-or-impure))_
+  - [dfnsFormatPure](https://date-fns.org/v2.16.0/docs/format)
+- [dfnsFormatDistance](https://date-fns.org/v2.16.0/docs/formatDistance) _([impure](#pure-or-impure))_
+  - [dfnsFormatDistancePure](https://date-fns.org/v2.16.0/docs/formatDistance)
+- [dfnsFormatDistanceStrict](https://date-fns.org/v2.16.0/docs/formatDistanceStrict) _([impure](#pure-or-impure))_
+  - [dfnsFormatDistanceStrictPure](https://date-fns.org/v2.16.0/docs/formatDistanceStrict)
+- [dfnsFormatDistanceToNow](https://date-fns.org/v2.16.0/docs/formatDistanceToNow) _([impure](#pure-or-impure))_
+  - [dfnsFormatDistanceToNowPure](https://date-fns.org/v2.16.0/docs/formatDistanceToNow)
+- [dfnsFormatDuration](https://date-fns.org/v2.16.0/docs/formatDuration) _([impure](#pure-or-impure))_
+  - [dfnsFormatDurationPure](https://date-fns.org/v2.16.0/docs/formatDuration)
 
-#### Misc
-
-- [dfnsParse](https://date-fns.org/v2.0.1/docs/parse) _([impure](#pure-or-impure))_
-  - [dfnsParsePure](https://date-fns.org/v2.0.1/docs/parse)
-- [dfnsParseIso](https://date-fns.org/v2.0.1/docs/parseISO)
-- [dfnsClosestTo](https://date-fns.org/v2.0.1/docs/closestTo)
-- [dfnsMin](https://date-fns.org/v2.0.1/docs/min)
-- [dfnsMax](https://date-fns.org/v2.0.1/docs/max)
+<a name="get-pipes" />
 
 #### Get
 
-- [dfnsGetOverlappingDaysInIntervals](https://date-fns.org/v2.0.1/docs/getOverlappingDaysInIntervals)
-- [dfnsGetTime](https://date-fns.org/v2.0.1/docs/getTime)
-- [dfnsGetMilliseconds](https://date-fns.org/v2.0.1/docs/getMilliseconds)
-- [dfnsGetSeconds](https://date-fns.org/v2.0.1/docs/getSeconds)
-- [dfnsGetMinutes](https://date-fns.org/v2.0.1/docs/getMinutes)
-- [dfnsGetHours](https://date-fns.org/v2.0.1/docs/getHours)
-- [dfnsGetDate](https://date-fns.org/v2.0.1/docs/getDate)
-- [dfnsGetDayOfYear](https://date-fns.org/v2.0.1/docs/getDayOfYear)
-- [dfnsGetDay](https://date-fns.org/v2.0.1/docs/getDay)
-- [dfnsGetISODay](https://date-fns.org/v2.0.1/docs/getISODay)
-- [dfnsGetISOWeek](https://date-fns.org/v2.0.1/docs/getISOWeek)
-- [dfnsGetDaysInMonth](https://date-fns.org/v2.0.1/docs/getDaysInMonth)
-- [dfnsGetMonth](https://date-fns.org/v2.0.1/docs/getMonth)
-- [dfnsGetQuarter](https://date-fns.org/v2.0.1/docs/getQuarter)
-- [dfnsGetDaysInYear](https://date-fns.org/v2.0.1/docs/getDaysInYear)
-- [dfnsGetYear](https://date-fns.org/v2.0.1/docs/getYear)
-- [dfnsGetISOWeeksInYear](https://date-fns.org/v2.0.1/docs/getISOWeeksInYear)
-- [dfnsGetISOWeekYear](https://date-fns.org/v2.0.1/docs/getISOWeekYear)
-- [dfnsGetUnixTime](https://date-fns.org/v2.0.1/docs/getUnixTime)
-- [dfnsGetWeek](https://date-fns.org/v2.0.1/docs/getWeek) _([impure](#pure-or-impure))_
-  - [dfnsGetWeekPure](https://date-fns.org/v2.0.1/docs/getWeek)
-- [dfnsGetWeekOfMonth](https://date-fns.org/v2.0.1/docs/getWeekOfMonth) _([impure](#pure-or-impure))_
-  - [dfnsGetWeekOfMonthPure](https://date-fns.org/v2.0.1/docs/getWeekOfMonth)
-- [dfnsGetWeeksInMonth](https://date-fns.org/v2.0.1/docs/getWeeksInMonth) _([impure](#pure-or-impure))_
-  - [dfnsGetWeeksInMonthPure](https://date-fns.org/v2.0.1/docs/getWeeksInMonth)
-- [dfnsGetDecade](https://date-fns.org/v2.0.1/docs/getDecade)
-- [dfnsGetWeekYear](https://date-fns.org/v2.0.1/docs/getWeekYear) _([impure](#pure-or-impure))_
-  - [dfnsGetWeekYearPure](https://date-fns.org/v2.0.1/docs/getWeekYear)
+- [dfnsGetOverlappingDaysInIntervals](https://date-fns.org/v2.16.0/docs/getOverlappingDaysInIntervals)
+- [dfnsGetTime](https://date-fns.org/v2.16.0/docs/getTime)
+- [dfnsGetMilliseconds](https://date-fns.org/v2.16.0/docs/getMilliseconds)
+- [dfnsGetSeconds](https://date-fns.org/v2.16.0/docs/getSeconds)
+- [dfnsGetMinutes](https://date-fns.org/v2.16.0/docs/getMinutes)
+- [dfnsGetHours](https://date-fns.org/v2.16.0/docs/getHours)
+- [dfnsGetDate](https://date-fns.org/v2.16.0/docs/getDate)
+- [dfnsGetDayOfYear](https://date-fns.org/v2.16.0/docs/getDayOfYear)
+- [dfnsGetDay](https://date-fns.org/v2.16.0/docs/getDay)
+- [dfnsGetISODay](https://date-fns.org/v2.16.0/docs/getISODay)
+- [dfnsGetISOWeek](https://date-fns.org/v2.16.0/docs/getISOWeek)
+- [dfnsGetDaysInMonth](https://date-fns.org/v2.16.0/docs/getDaysInMonth)
+- [dfnsGetMonth](https://date-fns.org/v2.16.0/docs/getMonth)
+- [dfnsGetQuarter](https://date-fns.org/v2.16.0/docs/getQuarter)
+- [dfnsGetDaysInYear](https://date-fns.org/v2.16.0/docs/getDaysInYear)
+- [dfnsGetYear](https://date-fns.org/v2.16.0/docs/getYear)
+- [dfnsGetISOWeeksInYear](https://date-fns.org/v2.16.0/docs/getISOWeeksInYear)
+- [dfnsGetISOWeekYear](https://date-fns.org/v2.16.0/docs/getISOWeekYear)
+- [dfnsGetUnixTime](https://date-fns.org/v2.16.0/docs/getUnixTime)
+- [dfnsGetWeek](https://date-fns.org/v2.16.0/docs/getWeek) _([impure](#pure-or-impure))_
+  - [dfnsGetWeekPure](https://date-fns.org/v2.16.0/docs/getWeek)
+- [dfnsGetWeekOfMonth](https://date-fns.org/v2.16.0/docs/getWeekOfMonth) _([impure](#pure-or-impure))_
+  - [dfnsGetWeekOfMonthPure](https://date-fns.org/v2.16.0/docs/getWeekOfMonth)
+- [dfnsGetWeeksInMonth](https://date-fns.org/v2.16.0/docs/getWeeksInMonth) _([impure](#pure-or-impure))_
+  - [dfnsGetWeeksInMonthPure](https://date-fns.org/v2.16.0/docs/getWeeksInMonth)
+- [dfnsGetDecade](https://date-fns.org/v2.16.0/docs/getDecade)
+- [dfnsGetWeekYear](https://date-fns.org/v2.16.0/docs/getWeekYear) _([impure](#pure-or-impure))_
+  - [dfnsGetWeekYearPure](https://date-fns.org/v2.16.0/docs/getWeekYear)
+
+<a name="difference-pipes" />
 
 #### Difference
 
-- [dfnsDifferenceInMilliseconds](https://date-fns.org/v2.0.1/docs/differenceInMilliseconds)
-- [dfnsDifferenceInSeconds](https://date-fns.org/v2.0.1/docs/differenceInSeconds)
-- [dfnsDifferenceInMinutes](https://date-fns.org/v2.0.1/docs/differenceInMinutes)
-- [dfnsDifferenceInHours](https://date-fns.org/v2.0.1/docs/differenceInHours)
-- [dfnsDifferenceInCalendarDays](https://date-fns.org/v2.0.1/docs/differenceInCalendarDays)
-- [dfnsDifferenceInBusinessDays](https://date-fns.org/v2.0.1/docs/differenceInBusinessDays)
-- [dfnsDifferenceInDays](https://date-fns.org/v2.0.1/docs/differenceInDays)
-- [dfnsDifferenceInCalendarWeeks](https://date-fns.org/v2.0.1/docs/differenceInCalendarWeeks)
-- [dfnsDifferenceInWeeks](https://date-fns.org/v2.0.1/docs/differenceInWeeks)
-- [dfnsDifferenceInCalendarISOWeeks](https://date-fns.org/v2.0.1/docs/differenceInCalendarISOWeeks)
-- [dfnsDifferenceInCalendarMonths](https://date-fns.org/v2.0.1/docs/differenceInCalendarMonths)
-- [dfnsDifferenceInMonths](https://date-fns.org/v2.0.1/docs/differenceInMonths)
-- [dfnsDifferenceInCalendarQuarters](https://date-fns.org/v2.0.1/docs/differenceInCalendarQuarters)
-- [dfnsDifferenceInQuarters](https://date-fns.org/v2.0.1/docs/differenceInQuarters)
-- [dfnsDifferenceInCalendarYears](https://date-fns.org/v2.0.1/docs/differenceInCalendarYears)
-- [dfnsDifferenceInYears](https://date-fns.org/v2.0.1/docs/differenceInYears)
-- [dfnsDifferenceInCalendarISOWeekYears](https://date-fns.org/v2.0.1/docs/differenceInCalendarISOWeekYears)
-- [dfnsDifferenceInISOWeekYears](https://date-fns.org/v2.0.1/docs/differenceInISOWeekYears)
+- [dfnsDifferenceInMilliseconds](https://date-fns.org/v2.16.0/docs/differenceInMilliseconds)
+- [dfnsDifferenceInSeconds](https://date-fns.org/v2.16.0/docs/differenceInSeconds)
+- [dfnsDifferenceInMinutes](https://date-fns.org/v2.16.0/docs/differenceInMinutes)
+- [dfnsDifferenceInHours](https://date-fns.org/v2.16.0/docs/differenceInHours)
+- [dfnsDifferenceInCalendarDays](https://date-fns.org/v2.16.0/docs/differenceInCalendarDays)
+- [dfnsDifferenceInBusinessDays](https://date-fns.org/v2.16.0/docs/differenceInBusinessDays)
+- [dfnsDifferenceInDays](https://date-fns.org/v2.16.0/docs/differenceInDays)
+- [dfnsDifferenceInCalendarWeeks](https://date-fns.org/v2.16.0/docs/differenceInCalendarWeeks)
+- [dfnsDifferenceInWeeks](https://date-fns.org/v2.16.0/docs/differenceInWeeks)
+- [dfnsDifferenceInCalendarISOWeeks](https://date-fns.org/v2.16.0/docs/differenceInCalendarISOWeeks)
+- [dfnsDifferenceInCalendarMonths](https://date-fns.org/v2.16.0/docs/differenceInCalendarMonths)
+- [dfnsDifferenceInMonths](https://date-fns.org/v2.16.0/docs/differenceInMonths)
+- [dfnsDifferenceInCalendarQuarters](https://date-fns.org/v2.16.0/docs/differenceInCalendarQuarters)
+- [dfnsDifferenceInQuarters](https://date-fns.org/v2.16.0/docs/differenceInQuarters)
+- [dfnsDifferenceInCalendarYears](https://date-fns.org/v2.16.0/docs/differenceInCalendarYears)
+- [dfnsDifferenceInYears](https://date-fns.org/v2.16.0/docs/differenceInYears)
+- [dfnsDifferenceInCalendarISOWeekYears](https://date-fns.org/v2.16.0/docs/differenceInCalendarISOWeekYears)
+- [dfnsDifferenceInISOWeekYears](https://date-fns.org/v2.16.0/docs/differenceInISOWeekYears)
+
+<a name="add-pipes" />
 
 #### Add
 
-- [dfnsAddMilliseconds](https://date-fns.org/v2.0.1/docs/addMilliseconds)
-- [dfnsAddSeconds](https://date-fns.org/v2.0.1/docs/addSeconds)
-- [dfnsAddMinutes](https://date-fns.org/v2.0.1/docs/addMinutes)
-- [dfnsAddHours](https://date-fns.org/v2.0.1/docs/addHours)
-- [dfnsAddBusinessDays](https://date-fns.org/v2.0.1/docs/addBusinessDays)
-- [dfnsAddDays](https://date-fns.org/v2.0.1/docs/addDays)
-- [dfnsAddWeeks](https://date-fns.org/v2.0.1/docs/addWeeks)
-- [dfnsAddMonths](https://date-fns.org/v2.0.1/docs/addMonths)
-- [dfnsAddQuarters](https://date-fns.org/v2.0.1/docs/addQuarters)
-- [dfnsAddYears](https://date-fns.org/v2.0.1/docs/addYears)
-- [dfnsAddISOWeekYears](https://date-fns.org/v2.0.1/docs/addISOWeekYears)
+- [dfnsAddMilliseconds](https://date-fns.org/v2.16.0/docs/addMilliseconds)
+- [dfnsAddSeconds](https://date-fns.org/v2.16.0/docs/addSeconds)
+- [dfnsAddMinutes](https://date-fns.org/v2.16.0/docs/addMinutes)
+- [dfnsAddHours](https://date-fns.org/v2.16.0/docs/addHours)
+- [dfnsAddBusinessDays](https://date-fns.org/v2.16.0/docs/addBusinessDays)
+- [dfnsAddDays](https://date-fns.org/v2.16.0/docs/addDays)
+- [dfnsAddWeeks](https://date-fns.org/v2.16.0/docs/addWeeks)
+- [dfnsAddMonths](https://date-fns.org/v2.16.0/docs/addMonths)
+- [dfnsAddQuarters](https://date-fns.org/v2.16.0/docs/addQuarters)
+- [dfnsAddYears](https://date-fns.org/v2.16.0/docs/addYears)
+- [dfnsAddISOWeekYears](https://date-fns.org/v2.16.0/docs/addISOWeekYears)
+
+<a name="subtract-pipes" />
 
 #### Subtract
 
-- [dfnsSubMilliseconds](https://date-fns.org/v2.0.1/docs/subMilliseconds)
-- [dfnsSubSeconds](https://date-fns.org/v2.0.1/docs/subSeconds)
-- [dfnsSubMinutes](https://date-fns.org/v2.0.1/docs/subMinutes)
-- [dfnsSubHours](https://date-fns.org/v2.0.1/docs/subHours)
-- [dfnsSubDays](https://date-fns.org/v2.0.1/docs/subDays)
-- [dfnsSubWeeks](https://date-fns.org/v2.0.1/docs/subWeeks)
-- [dfnsSubMonths](https://date-fns.org/v2.0.1/docs/subMonths)
-- [dfnsSubQuarters](https://date-fns.org/v2.0.1/docs/subQuarters)
-- [dfnsSubYears](https://date-fns.org/v2.0.1/docs/subYears)
-- [dfnsSubISOWeekYears](https://date-fns.org/v2.0.1/docs/subISOWeekYears)
+- [dfnsSubMilliseconds](https://date-fns.org/v2.16.0/docs/subMilliseconds)
+- [dfnsSubSeconds](https://date-fns.org/v2.16.0/docs/subSeconds)
+- [dfnsSubMinutes](https://date-fns.org/v2.16.0/docs/subMinutes)
+- [dfnsSubHours](https://date-fns.org/v2.16.0/docs/subHours)
+- [dfnsSubDays](https://date-fns.org/v2.16.0/docs/subDays)
+- [dfnsSubWeeks](https://date-fns.org/v2.16.0/docs/subWeeks)
+- [dfnsSubMonths](https://date-fns.org/v2.16.0/docs/subMonths)
+- [dfnsSubQuarters](https://date-fns.org/v2.16.0/docs/subQuarters)
+- [dfnsSubYears](https://date-fns.org/v2.16.0/docs/subYears)
+- [dfnsSubISOWeekYears](https://date-fns.org/v2.16.0/docs/subISOWeekYears)
+
+<a name="end-pipes" />
 
 #### End
 
-- [dfnsEndOfSecond](https://date-fns.org/v2.0.1/docs/endOfSecond)
-- [dfnsEndOfMinute](https://date-fns.org/v2.0.1/docs/endOfMinute)
-- [dfnsEndOfHour](https://date-fns.org/v2.0.1/docs/endOfHour)
-- [dfnsEndOfDay](https://date-fns.org/v2.0.1/docs/endOfDay)
-- [dfnsEndOfToday](https://date-fns.org/v2.0.1/docs/endOfToday)
-- [dfnsEndOfTomorrow](https://date-fns.org/v2.0.1/docs/endOfTomorrow)
-- [dfnsEndOfYesterday](https://date-fns.org/v2.0.1/docs/endOfYesterday)
-- [dfnsEndOfWeek](https://date-fns.org/v2.0.1/docs/endOfWeek)
-- [dfnsEndOfISOWeek](https://date-fns.org/v2.0.1/docs/endOfISOWeek)
-- [dfnsEndOfMonth](https://date-fns.org/v2.0.1/docs/endOfMonth)
-- [dfnsEndOfQuarter](https://date-fns.org/v2.0.1/docs/endOfQuarter)
-- [dfnsEndOfYear](https://date-fns.org/v2.0.1/docs/endOfYear)
-- [dfnsEndOfISOWeekYear](https://date-fns.org/v2.0.1/docs/endOfISOWeekYear)
+- [dfnsEndOfSecond](https://date-fns.org/v2.16.0/docs/endOfSecond)
+- [dfnsEndOfMinute](https://date-fns.org/v2.16.0/docs/endOfMinute)
+- [dfnsEndOfHour](https://date-fns.org/v2.16.0/docs/endOfHour)
+- [dfnsEndOfDay](https://date-fns.org/v2.16.0/docs/endOfDay)
+- [dfnsEndOfToday](https://date-fns.org/v2.16.0/docs/endOfToday)
+- [dfnsEndOfTomorrow](https://date-fns.org/v2.16.0/docs/endOfTomorrow)
+- [dfnsEndOfYesterday](https://date-fns.org/v2.16.0/docs/endOfYesterday)
+- [dfnsEndOfWeek](https://date-fns.org/v2.16.0/docs/endOfWeek)
+- [dfnsEndOfISOWeek](https://date-fns.org/v2.16.0/docs/endOfISOWeek)
+- [dfnsEndOfMonth](https://date-fns.org/v2.16.0/docs/endOfMonth)
+- [dfnsEndOfQuarter](https://date-fns.org/v2.16.0/docs/endOfQuarter)
+- [dfnsEndOfYear](https://date-fns.org/v2.16.0/docs/endOfYear)
+- [dfnsEndOfISOWeekYear](https://date-fns.org/v2.16.0/docs/endOfISOWeekYear)
+
+<a name="start-pipes" />
 
 #### Start
 
-- [dfnsStartOfSecond](https://date-fns.org/v2.0.1/docs/startOfSecond)
-- [dfnsStartOfMinute](https://date-fns.org/v2.0.1/docs/startOfMinute)
-- [dfnsStartOfHour](https://date-fns.org/v2.0.1/docs/startOfHour)
-- [dfnsStartOfDay](https://date-fns.org/v2.0.1/docs/startOfDay)
-- [dfnsStartOfToday](https://date-fns.org/v2.0.1/docs/startOfToday)
-- [dfnsStartOfTomorrow](https://date-fns.org/v2.0.1/docs/startOfTomorrow)
-- [dfnsStartOfYesterday](https://date-fns.org/v2.0.1/docs/startOfYesterday)
-- [dfnsStartOfWeek](https://date-fns.org/v2.0.1/docs/startOfWeek) _([impure](#pure-or-impure))_
-  - [dfnsStartOfWeekPure](https://date-fns.org/v2.0.1/docs/startOfWeek)
-- [dfnsStartOfISOWeek](https://date-fns.org/v2.0.1/docs/startOfISOWeek)
-- [dfnsStartOfMonth](https://date-fns.org/v2.0.1/docs/startOfMonth)
-- [dfnsStartOfQuarter](https://date-fns.org/v2.0.1/docs/startOfQuarter)
-- [dfnsStartOfYear](https://date-fns.org/v2.0.1/docs/startOfYear)
-- [dfnsStartOfISOWeekYear](https://date-fns.org/v2.0.1/docs/startOfISOWeekYear)
-- [dfnsStartOfDecade](https://date-fns.org/v2.0.1/docs/startOfDecade)
-- [dfnsStartOfWeekYear](https://date-fns.org/v2.0.1/docs/startOfWeekYear) _([impure](#pure-or-impure))_
-  - [dfnsStartOfWeekYearPure](https://date-fns.org/v2.0.1/docs/startOfWeekYear)
+- [dfnsStartOfSecond](https://date-fns.org/v2.16.0/docs/startOfSecond)
+- [dfnsStartOfMinute](https://date-fns.org/v2.16.0/docs/startOfMinute)
+- [dfnsStartOfHour](https://date-fns.org/v2.16.0/docs/startOfHour)
+- [dfnsStartOfDay](https://date-fns.org/v2.16.0/docs/startOfDay)
+- [dfnsStartOfToday](https://date-fns.org/v2.16.0/docs/startOfToday)
+- [dfnsStartOfTomorrow](https://date-fns.org/v2.16.0/docs/startOfTomorrow)
+- [dfnsStartOfYesterday](https://date-fns.org/v2.16.0/docs/startOfYesterday)
+- [dfnsStartOfWeek](https://date-fns.org/v2.16.0/docs/startOfWeek) _([impure](#pure-or-impure))_
+  - [dfnsStartOfWeekPure](https://date-fns.org/v2.16.0/docs/startOfWeek)
+- [dfnsStartOfISOWeek](https://date-fns.org/v2.16.0/docs/startOfISOWeek)
+- [dfnsStartOfMonth](https://date-fns.org/v2.16.0/docs/startOfMonth)
+- [dfnsStartOfQuarter](https://date-fns.org/v2.16.0/docs/startOfQuarter)
+- [dfnsStartOfYear](https://date-fns.org/v2.16.0/docs/startOfYear)
+- [dfnsStartOfISOWeekYear](https://date-fns.org/v2.16.0/docs/startOfISOWeekYear)
+- [dfnsStartOfDecade](https://date-fns.org/v2.16.0/docs/startOfDecade)
+- [dfnsStartOfWeekYear](https://date-fns.org/v2.16.0/docs/startOfWeekYear) _([impure](#pure-or-impure))_
+  - [dfnsStartOfWeekYearPure](https://date-fns.org/v2.16.0/docs/startOfWeekYear)
+
+<a name="last-day-of-pipes" />
 
 #### Last Day Of
 
-- [dfnsLastDayOfWeek](https://date-fns.org/v2.0.1/docs/lastDayOfWeek) _([impure](#pure-or-impure))_
-  - [dfnsLastDayOfWeekPure](https://date-fns.org/v2.0.1/docs/lastDayOfWeek)
-- [dfnsLastDayOfISOWeek](https://date-fns.org/v2.0.1/docs/lastDayOfISOWeek)
-- [dfnsLastDayOfMonth](https://date-fns.org/v2.0.1/docs/lastDayOfMonth)
-- [dfnsLastDayOfQuarter](https://date-fns.org/v2.0.1/docs/lastDayOfQuarter)
-- [dfnsLastDayOfYear](https://date-fns.org/v2.0.1/docs/lastDayOfYear)
-- [dfnsLastDayOfISOWeekYear](https://date-fns.org/v2.0.1/docs/lastDayOfISOWeekYear)
-- [dfnsLastDayOfDecade](https://date-fns.org/v2.0.1/docs/lastDayOfDecade)
+- [dfnsLastDayOfWeek](https://date-fns.org/v2.16.0/docs/lastDayOfWeek) _([impure](#pure-or-impure))_
+  - [dfnsLastDayOfWeekPure](https://date-fns.org/v2.16.0/docs/lastDayOfWeek)
+- [dfnsLastDayOfISOWeek](https://date-fns.org/v2.16.0/docs/lastDayOfISOWeek)
+- [dfnsLastDayOfMonth](https://date-fns.org/v2.16.0/docs/lastDayOfMonth)
+- [dfnsLastDayOfQuarter](https://date-fns.org/v2.16.0/docs/lastDayOfQuarter)
+- [dfnsLastDayOfYear](https://date-fns.org/v2.16.0/docs/lastDayOfYear)
+- [dfnsLastDayOfISOWeekYear](https://date-fns.org/v2.16.0/docs/lastDayOfISOWeekYear)
+- [dfnsLastDayOfDecade](https://date-fns.org/v2.16.0/docs/lastDayOfDecade)
+
+<a name="is-pipes" />
 
 #### Is...?
 
-- [dfnsIsAfter](https://date-fns.org/v2.0.1/docs/isAfter)
-- [dfnsIsBefore](https://date-fns.org/v2.0.1/docs/isBefore)
-- [dfnsIsDate](https://date-fns.org/v2.0.1/docs/isDate)
-- [dfnsIsEqual](https://date-fns.org/v2.0.1/docs/isEqual)
-- [dfnsIsFuture](https://date-fns.org/v2.0.1/docs/isFuture)
-- [dfnsIsPast](https://date-fns.org/v2.0.1/docs/isPast)
-- [dfnsIsValid](https://date-fns.org/v2.0.1/docs/isValid)
-- [dfnsIsToday](https://date-fns.org/v2.0.1/docs/isToday)
-- [dfnsIsWeekend](https://date-fns.org/v2.0.1/docs/isWeekend)
-- [dfnsIsSameMonth](https://date-fns.org/v2.0.1/docs/isSameMonth)
-- [dfnsIsSameYear](https://date-fns.org/v2.0.1/docs/isSameYear)
+- [dfnsIsAfter](https://date-fns.org/v2.16.0/docs/isAfter)
+- [dfnsIsBefore](https://date-fns.org/v2.16.0/docs/isBefore)
+- [dfnsIsDate](https://date-fns.org/v2.16.0/docs/isDate)
+- [dfnsIsEqual](https://date-fns.org/v2.16.0/docs/isEqual)
+- [dfnsIsFuture](https://date-fns.org/v2.16.0/docs/isFuture)
+- [dfnsIsPast](https://date-fns.org/v2.16.0/docs/isPast)
+- [dfnsIsValid](https://date-fns.org/v2.16.0/docs/isValid)
+- [dfnsIsToday](https://date-fns.org/v2.16.0/docs/isToday)
+- [dfnsIsWeekend](https://date-fns.org/v2.16.0/docs/isWeekend)
+- [dfnsIsSameMonth](https://date-fns.org/v2.16.0/docs/isSameMonth)
+- [dfnsIsSameYear](https://date-fns.org/v2.16.0/docs/isSameYear)
+
+<a name="utils" />
 
 ## Utils
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5813,9 +5813,9 @@
       }
     },
     "date-fns": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.8.1.tgz",
-      "integrity": "sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg=="
     },
     "date-format": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build:app": "ng build --namedChunks=true --sourceMap=true --prod",
     "analyze": "source-map-explorer dist/ngx-date-fns-app/main-es5.*.js",
     "prettier": "prettier --write src/app/**/*.ts && prettier --write projects/ngx-date-fns/src/lib/**/*.ts",
-    "precommit": "npm run lint && npm run test -- --watch=false",
+    "precommit": "npm run lint && npm run test",
     "e2e": "ng e2e",
     "cm": "git-cz",
     "cm-retry": "git-cz --retry",
@@ -60,7 +60,7 @@
     "@angular/platform-browser": "~11.2.1",
     "@angular/platform-browser-dynamic": "~11.2.1",
     "@angular/router": "~11.2.1",
-    "date-fns": "^2.0.1",
+    "date-fns": "^2.19.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/projects/ngx-date-fns/src/index.ts
+++ b/projects/ngx-date-fns/src/index.ts
@@ -130,6 +130,8 @@ export * from './lib/start-of-week-year.pure.pipe';
 export * from './lib/last-day-of-week.pure.pipe';
 export * from './lib/parse.pure.pipe';
 export * from './lib/parse-iso.pipe';
+export * from './lib/format-duration.pure.pipe';
+export * from './lib/format-duration.pipe';
 
 // Other stuff
 export * from './lib/types';

--- a/projects/ngx-date-fns/src/lib/date-fns.module.ts
+++ b/projects/ngx-date-fns/src/lib/date-fns.module.ts
@@ -133,6 +133,8 @@ import { StartOfWeekYearPurePipeModule } from './start-of-week-year.pure.pipe';
 import { LastDayOfWeekPurePipeModule } from './last-day-of-week.pure.pipe';
 import { ParsePurePipeModule } from './parse.pure.pipe';
 import { ParseIsoPipeModule } from './parse-iso.pipe';
+import { FormatDurationPipeModule } from './format-duration.pipe';
+import { FormatDurationPurePipeModule } from './format-duration.pure.pipe';
 
 const PIPES = [
   AddBusinessDaysPipeModule,
@@ -265,7 +267,9 @@ const PIPES = [
   StartOfWeekYearPurePipeModule,
   LastDayOfWeekPurePipeModule,
   ParsePurePipeModule,
-  ParseIsoPipeModule
+  ParseIsoPipeModule,
+  FormatDurationPipeModule,
+  FormatDurationPurePipeModule
 ];
 
 @NgModule({

--- a/projects/ngx-date-fns/src/lib/format-duration.pipe.spec.ts
+++ b/projects/ngx-date-fns/src/lib/format-duration.pipe.spec.ts
@@ -1,0 +1,162 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { DateFnsConfigurationService } from './date-fns-configuration.service';
+import { FormatDurationPipe } from './format-duration.pipe';
+import { es } from 'date-fns/locale';
+import { FormatDurationPurePipe } from './format-duration.pure.pipe';
+
+describe('FormatDurationPipe', () => {
+  let pipe: FormatDurationPipe;
+
+  const createPipe = () => {
+    const MyChangeDetector = class extends ChangeDetectorRef {
+      markForCheck(): void {
+        throw new Error('Method not implemented.');
+      }
+      detach(): void {
+        throw new Error('Method not implemented.');
+      }
+      detectChanges(): void {
+        throw new Error('Method not implemented.');
+      }
+      checkNoChanges(): void {
+        throw new Error('Method not implemented.');
+      }
+      reattach(): void {
+        throw new Error('Method not implemented.');
+      }
+    };
+    return new FormatDurationPipe(
+      new DateFnsConfigurationService(),
+      new MyChangeDetector()
+    );
+  };
+
+  beforeEach(() => {
+    pipe = createPipe();
+  });
+
+  it('should format full durations', () => {
+    expect(
+      pipe.transform({
+        years: 2,
+        months: 9,
+        weeks: 1,
+        days: 7,
+        hours: 5,
+        minutes: 9,
+        seconds: 30
+      })
+    ).toBe('2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds');
+  });
+
+  it('should format partial durations', () => {
+    expect(pipe.transform({ months: 9, days: 2 })).toBe('9 months 2 days');
+  });
+
+  it('should customize the format', () => {
+    expect(
+      pipe.transform(
+        {
+          years: 2,
+          months: 9,
+          weeks: 1,
+          days: 7,
+          hours: 5,
+          minutes: 9,
+          seconds: 30
+        },
+        { format: ['months', 'weeks'] }
+      )
+    ).toBe('9 months 1 week');
+  });
+
+  it('should customize the zeroes presence', () => {
+    expect(pipe.transform({ years: 0, months: 9 }, { zero: true })).toBe(
+      '0 years 9 months'
+    );
+  });
+
+  it('should customize the delimiter', () => {
+    expect(
+      pipe.transform({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
+    ).toBe('2 years, 9 months, 3 weeks');
+  });
+
+  it('should customize the locale', () => {
+    expect(
+      pipe.transform({ years: 2, months: 9, weeks: 3 }, { locale: es })
+    ).toBe('2 años 9 meses 3 semanas');
+  });
+});
+
+describe('FormatDurationPipe Pure', () => {
+  const createPipe = () =>
+    new FormatDurationPurePipe(new DateFnsConfigurationService());
+
+  it('should format full durations', () => {
+    expect(
+      createPipe().transform({
+        years: 2,
+        months: 9,
+        weeks: 1,
+        days: 7,
+        hours: 5,
+        minutes: 9,
+        seconds: 30
+      })
+    ).toBe('2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds');
+  });
+
+  it('should format partial durations', () => {
+    expect(createPipe().transform({ months: 9, days: 2 })).toBe(
+      '9 months 2 days'
+    );
+  });
+
+  it('should customize the format', () => {
+    expect(
+      createPipe().transform(
+        {
+          years: 2,
+          months: 9,
+          weeks: 1,
+          days: 7,
+          hours: 5,
+          minutes: 9,
+          seconds: 30
+        },
+        { format: ['months', 'weeks'] }
+      )
+    ).toBe('9 months 1 week');
+  });
+
+  it('should customize the zeroes presence', () => {
+    expect(
+      createPipe().transform({ years: 0, months: 9 }, { zero: true })
+    ).toBe('0 years 9 months');
+  });
+
+  it('should customize the delimiter', () => {
+    expect(
+      createPipe().transform(
+        { years: 2, months: 9, weeks: 3 },
+        { delimiter: ', ' }
+      )
+    ).toBe('2 years, 9 months, 3 weeks');
+  });
+
+  it('should customize the locale', () => {
+    expect(
+      createPipe().transform({ years: 2, months: 9, weeks: 3 }, { locale: es })
+    ).toBe('2 años 9 meses 3 semanas');
+  });
+
+  it('should customize the locale provided via config', () => {
+    const conf = new DateFnsConfigurationService();
+    conf.setLocale(es);
+    const pipe = new FormatDurationPurePipe(conf);
+    expect(pipe.transform({ years: 2, months: 9, weeks: 3 })).toBe(
+      '2 años 9 meses 3 semanas'
+    );
+  });
+});

--- a/projects/ngx-date-fns/src/lib/format-duration.pipe.ts
+++ b/projects/ngx-date-fns/src/lib/format-duration.pipe.ts
@@ -1,0 +1,50 @@
+import {
+  Pipe,
+  PipeTransform,
+  ChangeDetectorRef,
+  OnDestroy,
+  NgModule
+} from '@angular/core';
+import {
+  DateFnsConfigurationService,
+  calculateLocale
+} from './date-fns-configuration.service';
+import { Subscription } from 'rxjs';
+import { Locale } from 'date-fns';
+import formatDuration from 'date-fns/formatDuration';
+
+@Pipe({ name: 'dfnsFormatDuration', pure: false })
+export class FormatDurationPipe implements PipeTransform, OnDestroy {
+  private localeChanged$: Subscription;
+
+  constructor(
+    public config: DateFnsConfigurationService,
+    public cd: ChangeDetectorRef
+  ) {
+    this.localeChanged$ = this.config.localeChanged.subscribe(_ =>
+      this.cd.markForCheck()
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.localeChanged$.unsubscribe();
+  }
+
+  transform(
+    duration: Duration,
+    options?: {
+      format?: string[];
+      zero?: boolean;
+      delimiter?: string;
+      locale?: Locale;
+    }
+  ): string {
+    return formatDuration(duration, calculateLocale(options, this.config));
+  }
+}
+
+@NgModule({
+  declarations: [FormatDurationPipe],
+  exports: [FormatDurationPipe]
+})
+export class FormatDurationPipeModule {}

--- a/projects/ngx-date-fns/src/lib/format-duration.pure.pipe.ts
+++ b/projects/ngx-date-fns/src/lib/format-duration.pure.pipe.ts
@@ -1,0 +1,30 @@
+import { NgModule, Pipe, PipeTransform } from '@angular/core';
+import { Locale } from 'date-fns';
+import formatDuration from 'date-fns/formatDuration';
+import {
+  calculateLocale,
+  DateFnsConfigurationService
+} from './date-fns-configuration.service';
+
+@Pipe({ name: 'dfnsFormatDurationPure' })
+export class FormatDurationPurePipe implements PipeTransform {
+  constructor(public config: DateFnsConfigurationService) {}
+
+  transform(
+    duration: Duration,
+    options?: {
+      format?: string[];
+      zero?: boolean;
+      delimiter?: string;
+      locale?: Locale;
+    }
+  ): string {
+    return formatDuration(duration, calculateLocale(options, this.config));
+  }
+}
+
+@NgModule({
+  declarations: [FormatDurationPurePipe],
+  exports: [FormatDurationPurePipe]
+})
+export class FormatDurationPurePipeModule {}


### PR DESCRIPTION
Added two new pipes: `dfnsFormatDuration` and `dfnsFormatDurationPure`

BREAKING CHANGE: This version requires date-fns >= v2.16.0

#351