### PR TITLE
Date-fns v4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 
 - [Requirememnts](#requirememnts)
 - [Installation](#installation)
-  - [date-fns v3 support](#installation)
+  - [date-fns v4 support](#installation)
+  - [date-fns v3 support](#v3-support)
   - [date-fns v2 support](#v2-support)
   - [date-fns v1 support](#v1-support)
+- [Issues / feature requests](#issues-and-feat-reqs)
 - [Basic Usage](#usage)
 - [Working with locales](#locales)
   - [Changing locale globally](#locale-globally)
@@ -38,7 +40,7 @@
 
 The latest version of this library requires:
 
-- [date-fns](https://date-fns.org/) `>= v3.0.0`.
+- [date-fns](https://date-fns.org/) `= v4.x.x`.
 - Angular `>= v17.0.0`.
 
 <a name="installation" />
@@ -47,6 +49,14 @@ The latest version of this library requires:
 
 - `npm install --save date-fns`
 - `npm install --save ngx-date-fns`
+
+<a name="v3-support" />
+
+#### Installation for date-fns v3
+
+- `npm install --save date-fns@3.6.0`
+- `npm install --save ngx-date-fns@11.0.1`
+- [ngx-date-fns@11.0.1 docs](https://github.com/joanllenas/ngx-date-fns/tree/v11.0.1)
 
 <a name="v2-support" />
 
@@ -65,6 +75,12 @@ The latest version of this library requires:
 - `npm install --save date-fns@1.29.0`
 - `npm install --save ngx-date-fns@4.0.3`
 - [ngx-date-fns@4.0.3 docs](https://github.com/joanllenas/ngx-date-fns/tree/v4.0.3)
+
+<a name="issues-and-feat-reqs" />
+
+## Issues and Feature Requests
+
+This library has been around for more than 8 years and is largely complete, so don’t expect frequent new releases. If you notice missing functionality or encounter a bug, though, don’t hesitate to visit https://github.com/joanllenas/ngx-date-fns/issues and open an issue!
 
 <a name="usage" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-date-fns-workspace",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-date-fns-workspace",
-      "version": "11.0.0",
+      "version": "11.0.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",
@@ -17,7 +17,7 @@
         "@angular/platform-browser": "^17.0.0",
         "@angular/platform-browser-dynamic": "^17.0.0",
         "@angular/router": "^17.0.0",
-        "date-fns": "^3.0.6",
+        "date-fns": "^4.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.2"
@@ -6209,9 +6209,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.0.6.tgz",
-      "integrity": "sha512-W+G99rycpKMMF2/YD064b2lE7jJGUe+EjOES7Q8BIGY8sbNdbgcs9XFTZwvzc9Jx1f3k7LB7gZaZa7f8Agzljg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-date-fns-workspace",
-  "version": "11.0.1",
+  "version": "12.0.0",
   "description": "date-fns pipes for Angular",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-date-fns-workspace",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "date-fns pipes for Angular",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@angular/platform-browser": "^17.0.0",
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
-    "date-fns": "^3.0.6",
+    "date-fns": "^4.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2"

--- a/projects/app/src/styles.css
+++ b/projects/app/src/styles.css
@@ -11,3 +11,8 @@ ul {
   flex-direction: column;
   gap: 2px;
 }
+
+a.active {
+  font-weight: bold;
+  text-decoration: none;
+}

--- a/projects/ngx-date-fns/package.json
+++ b/projects/ngx-date-fns/package.json
@@ -4,7 +4,7 @@
   "peerDependencies": {
     "@angular/common": ">=17",
     "@angular/core": ">=17",
-    "date-fns": ">=3"
+    "date-fns": ">=4"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
This update only bumps the peer dependency version. No new features were added.
